### PR TITLE
Fork-Me-Link is now position: fixed

### DIFF
--- a/web/stylesheets/screen.css
+++ b/web/stylesheets/screen.css
@@ -119,7 +119,7 @@ div.shell {
 }
 
 a#forkme_banner {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 138px;


### PR DESCRIPTION
It somehow bugged me that this fork me banner doesn't stay in it's place
while scrolling, especially because on my system the scrolling amount is only a tiny bit, so about 40% of the banner stay always visible, no matter what you do (1920x1080px, 930ish px effective page height). 

As this is a descision mostly based on personal opinion, please review. 
